### PR TITLE
mime decode header before compare

### DIFF
--- a/message_highlight.php
+++ b/message_highlight.php
@@ -55,7 +55,8 @@ class message_highlight extends rcube_plugin
   // find a match for this message
   function mh_find_match($message) {
     foreach($this->prefs as $p) {
-      if(stristr($message->$p['header'], $p['input'])) {
+      $header = iconv_mime_decode($message->$p['header'], 2, 'UTF-8');
+      if(stristr($header, $p['input'])) {
         return($p['color']);
       }
     }


### PR DESCRIPTION
String compare only worked for non mime encoded headers (ascii).
For non english headers it is a rare case.

Caveat: this solution requires iconv PHP extension.