### PR TITLE
Fix brightness function for shorthand colors and invalid input

### DIFF
--- a/message_highlight.js
+++ b/message_highlight.js
@@ -79,6 +79,10 @@ function mh_receive_row(data) {
 
 /* calculate the brightness of a color */
 function brightness(hex) {
+    var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
+    hex = hex.replace(shorthandRegex, function(m, r, g, b) {
+        return r + r + g + g + b + b;
+    });
     var rgb = hex.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i)
     if (rgb === null) {
         return null;

--- a/message_highlight.js
+++ b/message_highlight.js
@@ -36,7 +36,8 @@ function mh_insert_row(evt) {
 
         evt.row.obj.style.backgroundColor = message.flags.plugin_mh_color;
 
-        if (brightness(message.flags.plugin_mh_color) < 123) {
+        var color_brightness = brightness(message.flags.plugin_mh_color);
+        if (color_brightness !== null && color_brightness < 123) {
             row.addClass('rcmfd_mh_row_dark');
         }
 
@@ -79,8 +80,11 @@ function mh_receive_row(data) {
 /* calculate the brightness of a color */
 function brightness(hex) {
     var rgb = hex.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i)
-            .slice(1,4)
-            .map(function(x) { return parseInt(x, 16); });
+    if (rgb === null) {
+        return null;
+    }
+    rgb = rgb.slice(1,4)
+             .map(function(x) { return parseInt(x, 16); });
 
     return (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000
 }


### PR DESCRIPTION
Supports use of shorthand colors like '#ddd' and makes the handling of regex-matching failures in the brightness function more robust.