### PR TITLE
Fix PHP warnings in storage_init

### DIFF
--- a/message_highlight.php
+++ b/message_highlight.php
@@ -49,7 +49,7 @@ class message_highlight extends rcube_plugin
    */
   function storage_init($p)
   {
-    $p['fetch_headers'] .= trim($p['fetch_headers']. ' ' . 'CC');
+    $p['fetch_headers'] = trim(($p['fetch_headers'] ?? '') . ' ' . 'CC');
     return($p);
   }
 


### PR DESCRIPTION
Fixes `PHP Warning:  Undefined array key "fetch_headers" in /usr/share/roundcube/plugins/message_highlight/message_highlight.php on line 52`

Resolves #26 